### PR TITLE
474 hsm

### DIFF
--- a/randomize/random.go
+++ b/randomize/random.go
@@ -1,6 +1,7 @@
 package randomize
 
 import (
+	"bytes"
 	"crypto/md5"
 	"fmt"
 	"math/rand"
@@ -19,13 +20,13 @@ func randStr(s *Seed, ln int) string {
 }
 
 func randAddr(s *Seed) string {
-	str := make([]byte, 42)
-	str[0] = byte(0)
-	str[1] = byte('x')
+	var buffer bytes.Buffer
+	buffer.WriteString("0")
+	buffer.WriteString("x")
 	for i := 2; i < 42; i++ {
-		str[i] = byte(alphabetAll[s.nextInt()%16])
+		buffer.WriteString(string(alphabetAll[s.nextInt()%16]))
 	}
-	return string(str)
+	return buffer.String()
 }
 
 func randStrLower(s *Seed, ln int) string {

--- a/randomize/random.go
+++ b/randomize/random.go
@@ -18,6 +18,16 @@ func randStr(s *Seed, ln int) string {
 	return string(str)
 }
 
+func randAddr(s *Seed) string {
+	str := make([]byte, 42)
+	str[0] = byte(0)
+	str[1] = byte('x')
+	for i := 2; i < 42; i++ {
+		str[i] = byte(alphabetAll[s.nextInt()%16])
+	}
+	return string(str)
+}
+
 func randStrLower(s *Seed, ln int) string {
 	str := make([]byte, ln)
 	for i := 0; i < ln; i++ {

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -164,6 +164,8 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 	kind := field.Kind()
 	typ := field.Type()
 
+	fmt.Printf("\n---- val %v - type %v -  name %v", field, fieldType, fieldName)
+
 	if strings.HasPrefix(fieldType, "enum") {
 		enum, err := randEnumValue(s, fieldType)
 		if err != nil {
@@ -214,6 +216,17 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 		value = null.NewString(randStrLower(s, 2), true)
 		field.Set(reflect.ValueOf(value))
 		return nil
+	} else if fieldName == "EthAccount" || fieldName == "PublicAddress" {
+		if typ == typeNullString {
+			value = null.NewString("0xBaC1Cd4051c378bF900087CCc445d7e7d02ad745", true)
+			field.Set(reflect.ValueOf(value))
+			return nil
+		} else {
+			value = "0xBaC1Cd4051c378bF900087CCc445d7e7d02ad745"
+			field.Set(reflect.ValueOf(value))
+			return nil
+		}
+
 	}
 
 	if foundValidated {

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -160,7 +160,7 @@ func randDate(s *Seed) time.Time {
 
 // If canBeNull is true:
 //  The value has the possibility of being null or non-zero at random.
-func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bool, fieldName string) error {
+func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bool, fieldName string) (err error) {
 	kind := field.Kind()
 	typ := field.Type()
 
@@ -226,10 +226,13 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					return nil
 				}
 				if fieldType == "uuid" {
-					randomUuid, err := uuid.NewV4()
-					if err != nil {
-						return err
-					}
+					randomUuid := uuid.NewV4()
+					defer func() {
+						if r := recover(); r != nil {
+							err = error.Error("Critical error generating new UUID")
+						}
+						err = error.Error("Couldn't recover from UUID panic")
+					}()
 					value = null.NewString(randomUuid.String(), true)
 					field.Set(reflect.ValueOf(value))
 					return nil
@@ -303,10 +306,13 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					return nil
 				}
 				if fieldType == "uuid" {
-					value, err := uuid.NewV4()
-					if err != nil {
-						return err
-					}
+					value := uuid.NewV4()
+					defer func() {
+						if r := recover(); r != nil {
+							err = error.Error("Critical error generating new UUID")
+						}
+						err = error.Error("Couldn't recover from UUID panic")
+					}()
 					field.Set(reflect.ValueOf(value.String()))
 					return nil
 				}
@@ -413,7 +419,7 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 	return nil
 }
 
-func getArrayRandValue(s *Seed, typ reflect.Type, fieldType string) interface{} {
+func getArrayRandValue(s *Seed, typ reflect.Type, fieldType string) (i interface{}) {
 	fieldType = strings.TrimLeft(fieldType, "ARRAY")
 	switch typ {
 	case typeInt64Array:
@@ -428,10 +434,13 @@ func getArrayRandValue(s *Seed, typ reflect.Type, fieldType string) interface{} 
 			return types.StringArray{value, value}
 		}
 		if fieldType == "uuid" {
-			randomUuid, err := uuid.NewV4()
-			if err != nil {
-				return err
-			}
+			randomUuid := uuid.NewV4()
+			defer func() {
+				if r := recover(); r != nil {
+					i = error.Error("Critical error generating new UUID")
+				}
+				i = error.Error("Couldn't recover from UUID panic")
+			}()
 			value := randomUuid.String()
 			return types.StringArray{value, value}
 		}

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -216,11 +216,11 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 		return nil
 	} else if fieldName == "EthAccount" || fieldName == "PublicAddress" {
 		if typ == typeNullString {
-			value = null.NewString("0xBaC1Cd4051c378bF900087CCc445d7e7d02ad745", true)
+			value = null.NewString(randAddr(s), true)
 			field.Set(reflect.ValueOf(value))
 			return nil
 		} else {
-			value = "0xBaC1Cd4051c378bF900087CCc445d7e7d02ad745"
+			value = randAddr(s)
 			field.Set(reflect.ValueOf(value))
 			return nil
 		}

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -231,7 +231,6 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 						if r := recover(); r != nil {
 							err = errors.Errorf("Critical error generating new UUID")
 						}
-						err = errors.Errorf("Couldn't recover from UUID panic")
 					}()
 					value = null.NewString(randomUuid.String(), true)
 					field.Set(reflect.ValueOf(value))
@@ -311,7 +310,6 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 						if r := recover(); r != nil {
 							err = errors.Errorf("Critical error generating new UUID")
 						}
-						err = errors.Errorf("Couldn't recover from UUID panic")
 					}()
 					field.Set(reflect.ValueOf(value.String()))
 					return nil
@@ -439,7 +437,6 @@ func getArrayRandValue(s *Seed, typ reflect.Type, fieldType string) (i interface
 				if r := recover(); r != nil {
 					i = errors.Errorf("Critical error generating new UUID")
 				}
-				i = errors.Errorf("Couldn't recover from UUID panic")
 			}()
 			value := randomUuid.String()
 			return types.StringArray{value, value}

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -229,9 +229,9 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					randomUuid := uuid.NewV4()
 					defer func() {
 						if r := recover(); r != nil {
-							err = error.Error("Critical error generating new UUID")
+							err = errors.Errorf("Critical error generating new UUID")
 						}
-						err = error.Error("Couldn't recover from UUID panic")
+						err = errors.Errorf("Couldn't recover from UUID panic")
 					}()
 					value = null.NewString(randomUuid.String(), true)
 					field.Set(reflect.ValueOf(value))
@@ -309,9 +309,9 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 					value := uuid.NewV4()
 					defer func() {
 						if r := recover(); r != nil {
-							err = error.Error("Critical error generating new UUID")
+							err = errors.Errorf("Critical error generating new UUID")
 						}
-						err = error.Error("Couldn't recover from UUID panic")
+						err = errors.Errorf("Couldn't recover from UUID panic")
 					}()
 					field.Set(reflect.ValueOf(value.String()))
 					return nil
@@ -437,9 +437,9 @@ func getArrayRandValue(s *Seed, typ reflect.Type, fieldType string) (i interface
 			randomUuid := uuid.NewV4()
 			defer func() {
 				if r := recover(); r != nil {
-					i = error.Error("Critical error generating new UUID")
+					i = errors.Errorf("Critical error generating new UUID")
 				}
-				i = error.Error("Couldn't recover from UUID panic")
+				i = errors.Errorf("Couldn't recover from UUID panic")
 			}()
 			value := randomUuid.String()
 			return types.StringArray{value, value}

--- a/randomize/randomize.go
+++ b/randomize/randomize.go
@@ -164,8 +164,6 @@ func randomizeField(s *Seed, field reflect.Value, fieldType string, canBeNull bo
 	kind := field.Kind()
 	typ := field.Type()
 
-	fmt.Printf("\n---- val %v - type %v -  name %v", field, fieldType, fieldName)
-
 	if strings.HasPrefix(fieldType, "enum") {
 		enum, err := randEnumValue(s, fieldType)
 		if err != nil {

--- a/templates/99_marshal.tpl
+++ b/templates/99_marshal.tpl
@@ -24,4 +24,3 @@ func (o {{$tableNameSingular}}) MarshalJSONFilter(exclude map[string]bool) ([]by
 func (o {{$tableNameSingular}}) JSONFilter(exclude map[string]bool) (res map[string]interface{}, err error) {
 	return marshal.JSONFilter(o, exclude)
 }
-

--- a/templates/99_marshal.tpl
+++ b/templates/99_marshal.tpl
@@ -25,7 +25,3 @@ func (o {{$tableNameSingular}}) JSONFilter(exclude map[string]bool) (res map[str
 	return marshal.JSONFilter(o, exclude)
 }
 
-// UnmarshalJSON will unmarshal the JSON data into the struct {{$tableNameSingular}}
-func (o {{$tableNameSingular}}) UnmarshalJSON(data []byte) error {
-    return marshal.UnmarshalWrapper(o, data, nil)
- }


### PR DESCRIPTION
- Error handling to match version 1.2.0 of satori/go.uuid package
- Random address to meet db contraints so the tests pass
- Removing generation of extra unmarshaling code. Unused and broken, causes issues when trying to unmarshal into `[]models.GeneratedStructSlice` 